### PR TITLE
SA2B - QoL changes

### DIFF
--- a/SA2B_Archipelago/SA2B_Archipelago/Aesthetics/MusicManager.cpp
+++ b/SA2B_Archipelago/SA2B_Archipelago/Aesthetics/MusicManager.cpp
@@ -72,3 +72,8 @@ void MusicManager::SetMusicShuffle(int shuffleType)
 {
     this->_ShuffleType = (MusicShuffleType)shuffleType;
 }
+
+void MusicManager::SetNarrator(int narrator)
+{
+    CurrentTheme = (char)narrator;
+}

--- a/SA2B_Archipelago/SA2B_Archipelago/Aesthetics/MusicManager.h
+++ b/SA2B_Archipelago/SA2B_Archipelago/Aesthetics/MusicManager.h
@@ -26,6 +26,8 @@ public:
 	void SetMusicMap(std::map<int, int> map);
 	void SetMusicShuffle(int shuffleType);
 
+	void SetNarrator(int narrator);
+
 //private:
 	const HelperFunctions* _helperFunctions;
 

--- a/SA2B_Archipelago/SA2B_Archipelago/Archipelago/ArchipelagoManager.cpp
+++ b/SA2B_Archipelago/SA2B_Archipelago/Archipelago/ArchipelagoManager.cpp
@@ -244,6 +244,13 @@ void SA2_SetMusicShuffle(int shuffleType)
     apm->SetMusicShuffle(shuffleType);
 }
 
+void SA2_SetNarrator(int narrator)
+{
+    ArchipelagoManager* apm = &ArchipelagoManager::getInstance();
+
+    apm->SetNarrator(narrator);
+}
+
 void SA2_SetEmblemsForCannonsCore(int emblemsRequired)
 {
     if (!ArchipelagoManager::getInstance().IsInit())
@@ -254,6 +261,22 @@ void SA2_SetEmblemsForCannonsCore(int emblemsRequired)
     StageSelectManager* ssm = &StageSelectManager::GetInstance();
 
     ssm->SetEmblemsForCannonsCore(emblemsRequired);
+}
+
+void SA2_SetRequiredCannonsCoreMissions(int requirement)
+{
+    if (!ArchipelagoManager::getInstance().IsInit())
+    {
+        return;
+    }
+
+    StageSelectManager* ssm = &StageSelectManager::GetInstance();
+
+    ssm->SetRequiredCannonsCoreMissions(requirement != 0);
+
+    LocationManager* locationManager = &LocationManager::getInstance();
+
+    locationManager->SetRequiredCannonsCoreMissions(requirement != 0);
 }
 
 void SA2_SetMissionCount(int missionCount)
@@ -405,7 +428,9 @@ void ArchipelagoManager::Init(const char* ip, const char* playerName, const char
     AP_RegisterSlotDataIntCallback("ModVersion", &SA2_CompareModVersion);
     AP_RegisterSlotDataMapIntIntCallback("MusicMap", &SA2_SetMusicMap);
     AP_RegisterSlotDataIntCallback("MusicShuffle", &SA2_SetMusicShuffle);
+    AP_RegisterSlotDataIntCallback("Narrator", &SA2_SetNarrator);
     AP_RegisterSlotDataIntCallback("EmblemsForCannonsCore", &SA2_SetEmblemsForCannonsCore);
+    AP_RegisterSlotDataIntCallback("RequiredCannonsCoreMissions", &SA2_SetRequiredCannonsCoreMissions);
     AP_RegisterSlotDataIntCallback("IncludeMissions", &SA2_SetMissionCount);
     AP_RegisterSlotDataIntCallback("RequiredRank", &SA2_SetRequiredRank);
     AP_RegisterSlotDataIntCallback("ChaoKeys", &SA2_SetChaoKeys);
@@ -633,6 +658,18 @@ void ArchipelagoManager::SetMusicShuffle(int shuffleType)
     MusicManager* musicManager = &MusicManager::getInstance();
 
     musicManager->SetMusicShuffle(shuffleType);
+}
+
+void ArchipelagoManager::SetNarrator(int narrator)
+{
+    if (!this->IsInit())
+    {
+        return;
+    }
+
+    MusicManager* musicManager = &MusicManager::getInstance();
+
+    musicManager->SetNarrator(narrator);
 }
 
 void ArchipelagoManager::SetDeathLink(bool deathLinkActive)

--- a/SA2B_Archipelago/SA2B_Archipelago/Archipelago/ArchipelagoManager.h
+++ b/SA2B_Archipelago/SA2B_Archipelago/Archipelago/ArchipelagoManager.h
@@ -53,6 +53,7 @@ private:
 
 	bool _authFailed = false;
 	bool _badSaveFile = false;
+	bool _badSaveName = false;
 	bool _badModVersion = false;
 
 	int _serverModVersion = 0;

--- a/SA2B_Archipelago/SA2B_Archipelago/Archipelago/ArchipelagoManager.h
+++ b/SA2B_Archipelago/SA2B_Archipelago/Archipelago/ArchipelagoManager.h
@@ -35,6 +35,7 @@ public:
 
 	void SetMusicMap(std::map<int, int> map);
 	void SetMusicShuffle(int shuffleType);
+	void SetNarrator(int narrator);
 	void SetDeathLink(bool deathLinkActive);
 	void VerfyModVersion(int modVersion);
 

--- a/SA2B_Archipelago/SA2B_Archipelago/Locations/LocationManager.cpp
+++ b/SA2B_Archipelago/SA2B_Archipelago/Locations/LocationManager.cpp
@@ -474,9 +474,20 @@ void LocationManager::CheckLocation(int location_id)
 	{
 		LevelClearCheckData& checkData = this->_LevelClearData[location_id];
 
-		if (location_id == LCC_CannonCore_1 || location_id >= LCC_Boss_1)
+		if (location_id >= LCC_Boss_1)
 		{
-			// Don't Collect Cannon's Core 1 or Bosses
+			// Don't Collect Bosses
+			return;
+		}
+
+		if (!this->_requireAllCannonsCoreMissions && location_id == LCC_CannonCore_1)
+		{
+			// Don't Collect Cannon's Core 1 (First Required)
+			return;
+		}
+		else if (this->_requireAllCannonsCoreMissions && (location_id >= LCC_CannonCore_1 && location_id <= LCC_CannonCore_5))
+		{
+			// Don't Collect any Cannon's Core Missions (All Active Required)
 			return;
 		}
 
@@ -611,6 +622,11 @@ void LocationManager::SetRacesPacked(bool racesPacked)
 void LocationManager::SetChaoEnabled(bool chaoEnabled)
 {
 	this->_chaoEnabled = chaoEnabled;
+}
+
+void LocationManager::SetRequiredCannonsCoreMissions(bool allMissionsRequired)
+{
+	this->_requireAllCannonsCoreMissions = allMissionsRequired;
 }
 
 void LocationManager::ResetLocations()

--- a/SA2B_Archipelago/SA2B_Archipelago/Locations/LocationManager.cpp
+++ b/SA2B_Archipelago/SA2B_Archipelago/Locations/LocationManager.cpp
@@ -566,6 +566,30 @@ void LocationManager::CheckLocation(int location_id)
 
 		WriteData<1>((void*)checkData.Address, 0x01);
 	}
+	else if (this->_PipeData.find(location_id) != this->_PipeData.end())
+	{
+		PipeCheckData& checkData = this->_PipeData[location_id];
+
+		checkData.CheckSent = true;
+
+		WriteData<1>((void*)checkData.Address, 0x01);
+	}
+	else if (this->_HiddenData.find(location_id) != this->_HiddenData.end())
+	{
+		HiddenCheckData& checkData = this->_HiddenData[location_id];
+
+		checkData.CheckSent = true;
+
+		WriteData<1>((void*)checkData.Address, 0x01);
+	}
+	else if (this->_GoldBeetleData.find(location_id) != this->_GoldBeetleData.end())
+	{
+		GoldBeetleCheckData& checkData = this->_GoldBeetleData[location_id];
+
+		checkData.CheckSent = true;
+
+		WriteData<1>((void*)checkData.Address, 0x01);
+	}
 }
 
 void LocationManager::SetRequiredRank(int requiredRank)
@@ -637,6 +661,26 @@ void LocationManager::ResetLocations()
 	}
 
 	for (auto& pair : this->_ChaoGardenData)
+	{
+		pair.second.CheckSent = false;
+	}
+
+	for (auto& pair : this->_ChaoKeyData)
+	{
+		pair.second.CheckSent = false;
+	}
+
+	for (auto& pair : this->_PipeData)
+	{
+		pair.second.CheckSent = false;
+	}
+
+	for (auto& pair : this->_HiddenData)
+	{
+		pair.second.CheckSent = false;
+	}
+
+	for (auto& pair : this->_GoldBeetleData)
 	{
 		pair.second.CheckSent = false;
 	}

--- a/SA2B_Archipelago/SA2B_Archipelago/Locations/LocationManager.h
+++ b/SA2B_Archipelago/SA2B_Archipelago/Locations/LocationManager.h
@@ -36,6 +36,7 @@ public:
 	void SetGoldBeetlesEnabled(bool goldBeetlesEnabled);
 	void SetRacesPacked(bool racesPacked);
 	void SetChaoEnabled(bool chaoEnabled);
+	void SetRequiredCannonsCoreMissions(bool requireAllCannonsCoreMissions);
 	void ResetLocations();
 
 	void SendChaoKeyLocationCheck();
@@ -51,6 +52,7 @@ private:
 	unsigned int _chaoTimer = 0;
 	unsigned int _whistleTimer = 0;
 	int _requiredRank = 0;
+	bool _requireAllCannonsCoreMissions = false;
 	bool _chaoKeysEnabled = false;
 	bool _pipesEnabled = false;
 	bool _hiddensEnabled = false;

--- a/SA2B_Archipelago/SA2B_Archipelago/Locations/StageSelectManager.cpp
+++ b/SA2B_Archipelago/SA2B_Archipelago/Locations/StageSelectManager.cpp
@@ -74,6 +74,11 @@ void StageSelectManager::SetEmblemsForCannonsCore(int emblemsRequired)
 	_emblemsForCannonsCore = emblemsRequired;
 }
 
+void StageSelectManager::SetRequiredCannonsCoreMissions(bool allMissionsRequired)
+{
+	this->_requireAllCannonsCoreMissions = allMissionsRequired;
+}
+
 void StageSelectManager::SetMissionCount(int missionCount)
 {
 	this->_missionCount = missionCount;
@@ -468,7 +473,29 @@ void StageSelectManager::HandleBossStage()
 
 void StageSelectManager::HandleBiolizard()
 {
-	if (CannonCore1_Rank > this->_requiredRank)
+	bool bCannonCoreComplete = true;
+
+	if (this->_requireAllCannonsCoreMissions)
+	{
+		// TODO: Adjust this when Mission Order changes go in
+		for (int i = 0; i < this->_missionCount; i++)
+		{
+			char dataValue = *(char*)(0x01DEE040 + i);
+
+			if (dataValue <= this->_requiredRank)
+			{
+				bCannonCoreComplete = false;
+
+				break;
+			}
+		}
+	}
+	else if (CannonCore1_Rank <= this->_requiredRank)
+	{
+		bCannonCoreComplete = false;
+	}
+
+	if (bCannonCoreComplete)
 	{
 		// Biolizard Tile
 		WriteData<1>((void*)this->_stageSelectDataMap[StageSelectStage::SSS_GreenHill].TileIDAddress, 0x41);

--- a/SA2B_Archipelago/SA2B_Archipelago/Locations/StageSelectManager.h
+++ b/SA2B_Archipelago/SA2B_Archipelago/Locations/StageSelectManager.h
@@ -51,6 +51,7 @@ public:
 	void OnInitFunction(const char* path, const HelperFunctions& helperFunctions);
 	void OnFrameFunction();
 	void SetEmblemsForCannonsCore(int emblemsRequired);
+	void SetRequiredCannonsCoreMissions(bool requireAllCannonsCoreMissions);
     void SetMissionCount(int missionCount);
     void SetRequiredRank(int requiredRank);
 	void SetRegionEmblemMap(std::map<int, int> map);
@@ -61,6 +62,7 @@ private:
 	std::map<int, StageSelectStageData> _stageSelectDataMap;
     std::map<int, StageSelectBossData> _stageSelectBossDataMap;
 	int _emblemsForCannonsCore = 200;
+	bool _requireAllCannonsCoreMissions = false;
 	int _missionCount = 1;
 	int _requiredRank = 0;
 	std::map<int, int> _regionEmblemMap;


### PR DESCRIPTION
Changelog:
- Added Menu Narrator option
- Added option to require all active Cannon's Core missions to be completed for access to the Biolizard
- Added feature to save slot name to the save file, to prevent sending incorrect data when using multiple slots of SA2B on the same seed
- Fix handling collects of new sanity options